### PR TITLE
bring Makefile and icons up-to-date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2014 Jiří Janoušek <janousek.jiri@gmail.com>
+# Copyright 2014-2015 Jiří Janoušek <janousek.jiri@gmail.com>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met: 
@@ -26,8 +26,17 @@ APP_ID = deezer
 DEPS = rsvg-convert
 # Default installation destination
 DEST ?= $(HOME)/.local/share/nuvolaplayer3/web_apps
-# Size of PNG app icon
-ICON_SIZE ?= 128
+# Sizes of the whole icon set
+ICON_SIZES = 16 22 24 32 48 64 128 256
+# Filenames
+INSTALL_FILES = metadata.json integrate.js
+LICENSES = LICENSE
+SOURCE_ICON = src/icon.svg
+SOURCE_ICON_XS = src/icon-xs.svg
+SOURCE_ICON_SM = src/icon-sm.svg
+ICONS_DIR ?= icons
+PNG_ICONS = $(foreach size,$(ICON_SIZES),$(ICONS_DIR)/$(size).png)
+SCALABLE_ICON = $(ICONS_DIR)/scalable.svg
 
 help:
 	@echo "make deps                - check whether dependencies are satisfied"
@@ -40,17 +49,66 @@ help:
 deps:
 	@$(foreach dep, $(DEPS), which $(dep) > /dev/null || (echo "Program $(dep) not found"; exit 1;);)
 
-build: deps icon.png 
+build: deps $(PNG_ICONS) $(SCALABLE_ICON)
 
-icon.png : src/icon.svg
-	rsvg-convert -w $(ICON_SIZE) -h $(ICON_SIZE) $< -o $@
+# Create icons dir
+$(ICONS_DIR):
+	mkdir -p $@
+	
+# Generate icon 16
+$(ICONS_DIR)/16.png: $(SOURCE_ICON_XS) | $(ICONS_DIR)
+	rsvg-convert -w 16 -h 16 $< -o $@
 
+# Generate icon 22	
+$(ICONS_DIR)/22.png : $(SOURCE_ICON_XS) | $(ICONS_DIR)
+	rsvg-convert -w 22 -h 22 $< -o $@
+
+# Generate icon 24	
+$(ICONS_DIR)/24.png : $(SOURCE_ICON_XS) | $(ICONS_DIR)
+	rsvg-convert -w 24 -h 24 $< -o $@
+
+# Generate icon 32	
+$(ICONS_DIR)/32.png : $(SOURCE_ICON_SM) | $(ICONS_DIR)
+	rsvg-convert -w 32 -h 32 $< -o $@
+
+# Generate icon 48
+$(ICONS_DIR)/48.png : $(SOURCE_ICON_SM) | $(ICONS_DIR)
+	rsvg-convert -w 48 -h 48 $< -o $@
+
+# Generate icons 64 128 256
+$(ICONS_DIR)/%.png : $(SOURCE_ICON) | $(ICONS_DIR)
+	rsvg-convert -w $* -h $* $< -o $@
+
+# Copy scalable icon
+$(SCALABLE_ICON) : $(SOURCE_ICON) | $(ICONS_DIR)
+	cp $< $@
+
+# Clean built files
 clean:
-	rm -f icon.png
+	rm -rf icons
 
-install: LICENSE metadata.json integrate.js icon.png
-	install -vCd $(DEST)/$(APP_ID)
-	install -vC $^ $(DEST)/$(APP_ID)
+# Install files
+install: $(LICENSES) $(INSTALL_FILES) $(PNG_ICONS) $(SCALABLE_ICON)
+	# Install data
+	install -vCd $(DEST)/$(APP_ID)/$(ICONS_DIR)
+	install -vC -t $(DEST)/$(APP_ID) $(LICENSES) $(INSTALL_FILES)
+	install -vC -t $(DEST)/$(APP_ID)/$(ICONS_DIR) $(PNG_ICONS) $(SCALABLE_ICON)
+	
+	# Create symlinks to icons
+	mkdir -pv $(DEST)/../../icons/hicolor/scalable/apps || true
+	ln -s -f -v -T ../../../../nuvolaplayer3/web_apps/$(APP_ID)/$(SCALABLE_ICON) \
+		$(DEST)/../../icons/hicolor/scalable/apps/nuvolaplayer3_$(APP_ID).svg;
+	for size in $(ICON_SIZES); do \
+		mkdir -pv $(DEST)/../../icons/hicolor/$${size}x$${size}/apps || true ; \
+		ln -s -f -v -T ../../../../nuvolaplayer3/web_apps/$(APP_ID)/$(ICONS_DIR)/$$size.png \
+		$(DEST)/../../icons/hicolor/$${size}x$${size}/apps/nuvolaplayer3_$(APP_ID).png; \
+	done
+	
 
+# Uninstall files
 uninstall:
-	rm -rv $(DEST)/$(APP_ID)
+	rm -fv $(DEST)/../../icons/hicolor/scalable/apps/nuvolaplayer3_$(APP_ID).svg
+	for size in $(ICON_SIZES); do \
+		rm -fv $(DEST)/../../icons/hicolor/$${size}x$${size}/apps/nuvolaplayer3_$(APP_ID).png; \
+	done
+	rm -rfv $(DEST)/$(APP_ID)

--- a/src/icon-sm.svg
+++ b/src/icon-sm.svg
@@ -8,8 +8,8 @@
    xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    id="svg3146"
-   height="512"
-   width="512">
+   height="32"
+   width="32">
   <defs
      id="defs3148">
     <linearGradient
@@ -64,11 +64,11 @@
     </rdf:RDF>
   </metadata>
   <g
-     transform="translate(-123.68846,-613.97778)"
+     transform="translate(-123.68846,-1093.9778)"
      id="layer1">
     <g
        style="display:inline;fill:url(#linearGradient4110);fill-opacity:1"
-       transform="matrix(8.0080435,0,0,8.0194456,123.43109,612.991)"
+       transform="matrix(0.50050291,0,0,0.50121554,123.67237,1093.9161)"
        id="g3996">
       <rect
          style="fill:url(#linearGradient3144);fill-opacity:1;stroke:none"
@@ -82,151 +82,151 @@
   </g>
   <g
      style="display:inline"
-     transform="translate(219.34369,-113.53798)"
+     transform="translate(219.34369,-593.53798)"
      id="layer4">
     <rect
        transform="scale(-1,1)"
        style="display:inline;fill:#333333;fill-opacity:1;stroke:none"
        id="rect5533-3-4-1-0-3-0-1-1"
-       width="413.5383"
-       height="137.8461"
-       x="-243.42537"
-       y="389.23026" />
+       width="25.846153"
+       height="8.6153851"
+       x="190.42061"
+       y="610.76868" />
     <rect
        transform="scale(-1,1)"
-       y="271.07645"
-       x="-47.536892"
-       height="118.1538"
-       width="118.1538"
+       y="603.38409"
+       x="202.66365"
+       height="7.3846154"
+       width="7.3846154"
        id="rect5533-2-9-6-8-8-6-9-4-1-4"
        style="display:inline;fill:#333333;fill-opacity:1;stroke:none" />
     <rect
        transform="scale(-1,1)"
-       y="330.15335"
-       x="-126.43532"
-       height="59.0769"
-       width="78.769203"
+       y="607.07642"
+       x="197.7325"
+       height="3.6923077"
+       width="4.9230771"
        id="rect5533-2-9-6-8-8-6-9-4-1-0-1"
        style="display:inline;fill:#333333;fill-opacity:1;stroke:none" />
     <rect
        transform="scale(-1,1)"
-       y="211.99954"
-       x="-243.42537"
-       height="177.2307"
-       width="118.1538"
+       y="599.69177"
+       x="190.42061"
+       height="11.076923"
+       width="7.3846154"
        id="rect5533-2-9-6-8-8-6-9-4-1-0-8-4"
        style="display:inline;fill:#333333;fill-opacity:1;stroke:none" />
     <rect
        transform="scale(-1,1)"
        style="display:inline;fill:#666666;fill-opacity:1;stroke:none"
        id="rect5533-2-4-6-8-0"
-       width="78.769203"
-       height="39.384602"
-       x="-125.27155"
-       y="467.99954" />
+       width="4.9230771"
+       height="2.4615386"
+       x="197.80522"
+       y="615.69177" />
     <rect
        transform="scale(-1,1)"
        style="display:inline;fill:#666666;fill-opacity:1;stroke:none"
        id="rect5533-2-9-6-8-2-1-0-3"
-       width="78.769203"
-       height="39.384602"
-       x="-125.27155"
-       y="408.92239" />
+       width="4.9230771"
+       height="2.4615386"
+       x="197.80522"
+       y="611.99945" />
     <rect
        transform="scale(-1,1)"
        style="display:inline;fill:#000000;fill-opacity:1;stroke:none"
        id="rect5533-2-9-42-0-1-5"
-       width="78.769203"
-       height="39.384602"
-       x="-223.73308"
-       y="467.99954" />
+       width="4.9230771"
+       height="2.4615386"
+       x="191.65138"
+       y="615.69177" />
     <rect
        transform="scale(-1,1)"
-       y="408.92239"
-       x="-26.810041"
-       height="39.384602"
-       width="78.769203"
+       y="611.99945"
+       x="203.95908"
+       height="2.4615386"
+       width="4.9230771"
        id="rect5533-3-4-1-8-6-3-1-4-2-2-4"
        style="display:inline;fill:#000000;fill-opacity:1;stroke:none" />
     <rect
        transform="scale(-1,1)"
        style="display:inline;fill:#000000;fill-opacity:1;stroke:none"
        id="rect5533-3-4-1-8-01-9-71-8"
-       width="78.769203"
-       height="39.384602"
-       x="-26.810041"
-       y="467.99954" />
+       width="4.9230771"
+       height="2.4615386"
+       x="203.95908"
+       y="615.69177" />
     <rect
        transform="scale(-1,1)"
-       y="408.92239"
-       x="71.651413"
-       height="39.384602"
-       width="78.769203"
+       y="611.99945"
+       x="210.11292"
+       height="2.4615386"
+       width="4.9230771"
        id="rect5533-3-4-1-8-6-3-1-4-2-4-0-0"
        style="display:inline;fill:#666666;fill-opacity:1;stroke:none" />
     <rect
        transform="scale(-1,1)"
        style="display:inline;fill:#666666;fill-opacity:1;stroke:none"
        id="rect5533-3-4-1-0-3-0-0"
-       width="78.769203"
-       height="39.384602"
-       x="71.651413"
-       y="467.99954" />
+       width="4.9230771"
+       height="2.4615386"
+       x="210.11292"
+       y="615.69177" />
     <rect
        transform="scale(-1,1)"
-       y="408.92239"
-       x="-223.73308"
-       height="39.384602"
-       width="78.769203"
+       y="611.99945"
+       x="191.65138"
+       height="2.4615386"
+       width="4.9230771"
        id="rect5533-2-9-6-8-8-6-9-4-0"
        style="display:inline;fill:#000000;fill-opacity:1;stroke:none" />
     <rect
        transform="scale(-1,1)"
-       y="349.84561"
-       x="-223.73308"
-       height="39.384602"
-       width="78.769203"
+       y="608.30719"
+       x="191.65138"
+       height="2.4615386"
+       width="4.9230771"
        id="rect5533-3-4-1-8-6-5-6-2-8-6-6-9-0"
        style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none" />
     <rect
        transform="scale(-1,1)"
-       y="349.84561"
-       x="-26.810041"
-       height="39.384602"
-       width="78.769203"
+       y="608.30719"
+       x="203.95908"
+       height="2.4615386"
+       width="4.9230771"
        id="rect5533-2-9-7-9-7-4-3-8"
        style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none" />
     <rect
        transform="scale(-1,1)"
        style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none"
        id="rect5533-3-4-1-8-0-9-6-2-5-0-5"
-       width="78.769203"
-       height="39.384602"
-       x="-223.73308"
-       y="290.76871" />
+       width="4.9230771"
+       height="2.4615386"
+       x="191.65138"
+       y="604.61487" />
     <rect
        transform="scale(-1,1)"
-       y="231.6918"
-       x="-223.73308"
-       height="39.384602"
-       width="78.769203"
+       y="600.92255"
+       x="191.65138"
+       height="2.4615386"
+       width="4.9230771"
        id="rect5533-3-4-1-8-6-3-1-4-2-8-45-9-1"
        style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none" />
     <rect
        transform="scale(-1,1)"
        style="fill:#ffffff;fill-opacity:1;stroke:none"
        id="rect5533-8-6-3-6-6"
-       width="78.769203"
-       height="39.384602"
-       x="-26.810041"
-       y="290.76871" />
+       width="4.9230771"
+       height="2.4615386"
+       x="203.95908"
+       y="604.61487" />
     <rect
        transform="scale(-1,1)"
        style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none"
        id="rect5533-2-4-6-8-0-6"
-       width="78.769203"
-       height="39.384602"
-       x="-125.27155"
-       y="349.84561" />
+       width="4.9230771"
+       height="2.4615386"
+       x="197.80522"
+       y="608.30719" />
   </g>
 </svg>

--- a/src/icon-xs.svg
+++ b/src/icon-xs.svg
@@ -8,8 +8,8 @@
    xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    id="svg3146"
-   height="512"
-   width="512">
+   height="16"
+   width="16">
   <defs
      id="defs3148">
     <linearGradient
@@ -64,11 +64,11 @@
     </rdf:RDF>
   </metadata>
   <g
-     transform="translate(-123.68846,-613.97778)"
+     transform="translate(-123.68846,-1109.9778)"
      id="layer1">
     <g
        style="display:inline;fill:url(#linearGradient4110);fill-opacity:1"
-       transform="matrix(8.0080435,0,0,8.0194456,123.43109,612.991)"
+       transform="matrix(0.25025146,0,0,0.25060777,123.68041,1109.947)"
        id="g3996">
       <rect
          style="fill:url(#linearGradient3144);fill-opacity:1;stroke:none"
@@ -82,151 +82,151 @@
   </g>
   <g
      style="display:inline"
-     transform="translate(219.34369,-113.53798)"
+     transform="translate(219.34369,-609.53798)"
      id="layer4">
     <rect
        transform="scale(-1,1)"
        style="display:inline;fill:#333333;fill-opacity:1;stroke:none"
        id="rect5533-3-4-1-0-3-0-1-1"
-       width="413.5383"
-       height="137.8461"
-       x="-243.42537"
-       y="389.23026" />
+       width="12.923077"
+       height="4.3076925"
+       x="204.88216"
+       y="618.15308" />
     <rect
        transform="scale(-1,1)"
-       y="271.07645"
-       x="-47.536892"
-       height="118.1538"
-       width="118.1538"
+       y="614.46082"
+       x="211.00368"
+       height="3.6923077"
+       width="3.6923077"
        id="rect5533-2-9-6-8-8-6-9-4-1-4"
        style="display:inline;fill:#333333;fill-opacity:1;stroke:none" />
     <rect
        transform="scale(-1,1)"
-       y="330.15335"
-       x="-126.43532"
-       height="59.0769"
-       width="78.769203"
+       y="616.30695"
+       x="208.5381"
+       height="1.8461539"
+       width="2.4615386"
        id="rect5533-2-9-6-8-8-6-9-4-1-0-1"
        style="display:inline;fill:#333333;fill-opacity:1;stroke:none" />
     <rect
        transform="scale(-1,1)"
-       y="211.99954"
-       x="-243.42537"
-       height="177.2307"
-       width="118.1538"
+       y="612.61462"
+       x="204.88216"
+       height="5.5384617"
+       width="3.6923077"
        id="rect5533-2-9-6-8-8-6-9-4-1-0-8-4"
        style="display:inline;fill:#333333;fill-opacity:1;stroke:none" />
     <rect
        transform="scale(-1,1)"
        style="display:inline;fill:#666666;fill-opacity:1;stroke:none"
        id="rect5533-2-4-6-8-0"
-       width="78.769203"
-       height="39.384602"
-       x="-125.27155"
-       y="467.99954" />
+       width="2.4615386"
+       height="1.2307693"
+       x="208.57446"
+       y="620.61462" />
     <rect
        transform="scale(-1,1)"
        style="display:inline;fill:#666666;fill-opacity:1;stroke:none"
        id="rect5533-2-9-6-8-2-1-0-3"
-       width="78.769203"
-       height="39.384602"
-       x="-125.27155"
-       y="408.92239" />
+       width="2.4615386"
+       height="1.2307693"
+       x="208.57446"
+       y="618.76849" />
     <rect
        transform="scale(-1,1)"
        style="display:inline;fill:#000000;fill-opacity:1;stroke:none"
        id="rect5533-2-9-42-0-1-5"
-       width="78.769203"
-       height="39.384602"
-       x="-223.73308"
-       y="467.99954" />
+       width="2.4615386"
+       height="1.2307693"
+       x="205.49754"
+       y="620.61462" />
     <rect
        transform="scale(-1,1)"
-       y="408.92239"
-       x="-26.810041"
-       height="39.384602"
-       width="78.769203"
+       y="618.76849"
+       x="211.65138"
+       height="1.2307693"
+       width="2.4615386"
        id="rect5533-3-4-1-8-6-3-1-4-2-2-4"
        style="display:inline;fill:#000000;fill-opacity:1;stroke:none" />
     <rect
        transform="scale(-1,1)"
        style="display:inline;fill:#000000;fill-opacity:1;stroke:none"
        id="rect5533-3-4-1-8-01-9-71-8"
-       width="78.769203"
-       height="39.384602"
-       x="-26.810041"
-       y="467.99954" />
+       width="2.4615386"
+       height="1.2307693"
+       x="211.65138"
+       y="620.61462" />
     <rect
        transform="scale(-1,1)"
-       y="408.92239"
-       x="71.651413"
-       height="39.384602"
-       width="78.769203"
+       y="618.76849"
+       x="214.7283"
+       height="1.2307693"
+       width="2.4615386"
        id="rect5533-3-4-1-8-6-3-1-4-2-4-0-0"
        style="display:inline;fill:#666666;fill-opacity:1;stroke:none" />
     <rect
        transform="scale(-1,1)"
        style="display:inline;fill:#666666;fill-opacity:1;stroke:none"
        id="rect5533-3-4-1-0-3-0-0"
-       width="78.769203"
-       height="39.384602"
-       x="71.651413"
-       y="467.99954" />
+       width="2.4615386"
+       height="1.2307693"
+       x="214.7283"
+       y="620.61462" />
     <rect
        transform="scale(-1,1)"
-       y="408.92239"
-       x="-223.73308"
-       height="39.384602"
-       width="78.769203"
+       y="618.76849"
+       x="205.49754"
+       height="1.2307693"
+       width="2.4615386"
        id="rect5533-2-9-6-8-8-6-9-4-0"
        style="display:inline;fill:#000000;fill-opacity:1;stroke:none" />
     <rect
        transform="scale(-1,1)"
-       y="349.84561"
-       x="-223.73308"
-       height="39.384602"
-       width="78.769203"
+       y="616.92236"
+       x="205.49754"
+       height="1.2307693"
+       width="2.4615386"
        id="rect5533-3-4-1-8-6-5-6-2-8-6-6-9-0"
        style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none" />
     <rect
        transform="scale(-1,1)"
-       y="349.84561"
-       x="-26.810041"
-       height="39.384602"
-       width="78.769203"
+       y="616.92236"
+       x="211.65138"
+       height="1.2307693"
+       width="2.4615386"
        id="rect5533-2-9-7-9-7-4-3-8"
        style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none" />
     <rect
        transform="scale(-1,1)"
        style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none"
        id="rect5533-3-4-1-8-0-9-6-2-5-0-5"
-       width="78.769203"
-       height="39.384602"
-       x="-223.73308"
-       y="290.76871" />
+       width="2.4615386"
+       height="1.2307693"
+       x="205.49754"
+       y="615.07617" />
     <rect
        transform="scale(-1,1)"
-       y="231.6918"
-       x="-223.73308"
-       height="39.384602"
-       width="78.769203"
+       y="613.23004"
+       x="205.49754"
+       height="1.2307693"
+       width="2.4615386"
        id="rect5533-3-4-1-8-6-3-1-4-2-8-45-9-1"
        style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none" />
     <rect
        transform="scale(-1,1)"
        style="fill:#ffffff;fill-opacity:1;stroke:none"
        id="rect5533-8-6-3-6-6"
-       width="78.769203"
-       height="39.384602"
-       x="-26.810041"
-       y="290.76871" />
+       width="2.4615386"
+       height="1.2307693"
+       x="211.65138"
+       y="615.07617" />
     <rect
        transform="scale(-1,1)"
        style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none"
        id="rect5533-2-4-6-8-0-6"
-       width="78.769203"
-       height="39.384602"
-       x="-125.27155"
-       y="349.84561" />
+       width="2.4615386"
+       height="1.2307693"
+       x="208.57446"
+       y="616.92236" />
   </g>
 </svg>


### PR DESCRIPTION
This brings the Makefile into line with the [Google Play integration](https://github.com/tiliado/nuvola-app-google-play-music/blob/master/Makefile), and also dramatically reduces the size of the source SVGs without any loss of quality.

This includes PR tiliado/nuvola-app-google-play-music/pull/13, and allows clean application of the Gist from tiliado/nuvola-app-google-play-music/pull/14.

(Submitted because I've found myself maintaining the PKGBUILD for it on the AUR.)
